### PR TITLE
[1.11]Set supervisor user as root

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon = true
+user = root
 pidfile = /run/supervisord.pid
 
 [program:nginx]


### PR DESCRIPTION
CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.