### PR TITLE
[docker][experimental]daemonize php-fpm process

### DIFF
--- a/experimental/.docker/fpm.conf
+++ b/experimental/.docker/fpm.conf
@@ -1,5 +1,5 @@
 [global]
-daemonize = yes
+daemonize = no
 
 error_log = /var/log/php-fpm/error.log
 log_level = error


### PR DESCRIPTION
I don't know why, but for some reason, we have to keep the php-fpm process in the foreground.